### PR TITLE
Moved whitespace out of link

### DIFF
--- a/js/src/forum/components/ForumStatisticsWidget.js
+++ b/js/src/forum/components/ForumStatisticsWidget.js
@@ -93,9 +93,9 @@ export default class ForumStatisticsWidget extends Component {
             items.add(
                 'latest_member',
                 <li>
-                    {app.translator.trans(translationPrefix + 'latest_member')}
+                    {app.translator.trans(translationPrefix + 'latest_member')}{' '}
                     <Link href={app.route.user(this.user)}>
-                        <strong> {username(this.user)}</strong>
+                        <strong>{username(this.user)}</strong>
                     </Link>
                 </li>
             );


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes**
Link to last user containing a whitspace

**Reviewers should focus on:**
testing the frontend, to see that is still works and looks good

**Screenshot**
![image](https://user-images.githubusercontent.com/18526076/129925438-ccdf81ae-8b9f-4ceb-98af-2d2f2d2536e2.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
