### PR TITLE
feat: add Classic Look setting to restore pre-widgets-core appearance

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -27,7 +27,9 @@ return [
     (new Extend\Settings())
         ->default('fof-forum-statistics-widget.ignore_private_discussions', false)
         ->default('fof-forum-statistics-widget.cache_duration', 600)
-        ->default('fof-forum-statistics-widget.flush_cache_on_new_registration', false),
+        ->default('fof-forum-statistics-widget.flush_cache_on_new_registration', false)
+        ->default('fof-forum-statistics-widget.classic_look', false)
+        ->serializeToForum('fof-forum-statistics-widget.classicLook', 'fof-forum-statistics-widget.classic_look', 'boolval'),
 
     (new Extend\ApiSerializer(ForumSerializer::class))
         ->attributes(AddForumStats::class),

--- a/js/src/admin/index.ts
+++ b/js/src/admin/index.ts
@@ -15,6 +15,12 @@ app.initializers.add('fof-forum-statistics-widget', () => {
       type: 'switch',
     })
     .registerSetting({
+      setting: 'fof-forum-statistics-widget.classic_look',
+      type: 'switch',
+      label: app.translator.trans(translationPrefix + 'settings.classic_look_label'),
+      help: app.translator.trans(translationPrefix + 'settings.classic_look_help'),
+    })
+    .registerSetting({
       setting: 'fof-forum-statistics-widget.cache_duration',
       type: 'number',
       min: 0,

--- a/js/src/common/components/ForumStatisticsWidget.tsx
+++ b/js/src/common/components/ForumStatisticsWidget.tsx
@@ -29,8 +29,13 @@ export default class ForumStatisticsWidget extends Widget<WidgetAttrs> {
     }
   }
 
+  isClassicLook(): boolean {
+    return !!(app.forum.attribute<boolean>(attributePrefix + 'classicLook') as unknown as boolean | undefined);
+  }
+
   className(): string {
-    return 'FoF-ForumStatisticsWidget';
+    const base = 'FoF-ForumStatisticsWidget';
+    return this.isClassicLook() ? `${base} ${base}--classic` : base;
   }
 
   icon(): string {
@@ -53,6 +58,21 @@ export default class ForumStatisticsWidget extends Widget<WidgetAttrs> {
     const items = this.items().toArray();
 
     if (items.length === 0) return null;
+
+    if (this.isClassicLook()) {
+      return (
+        <div className="ForumStatistics containerNarrow">
+          <div className="row">
+            <h2>
+              <i className="fas fa-chart-bar" /> {app.translator.trans(translationPrefix + 'widget_title')}
+            </h2>
+            <div>
+              <ul id="ForumStatisticsList">{items}</ul>
+            </div>
+          </div>
+        </div>
+      );
+    }
 
     return <ul className="ForumStatisticsList">{items}</ul>;
   }

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -1,7 +1,54 @@
+// ============================================================
+// Forum Statistics Widget — New look (fof/forum-widgets-core)
+// ============================================================
+// These styles apply when the "Classic look" admin setting is OFF.
+// The widget container and title bar are rendered by the Widget
+// base class from fof/forum-widgets-core. Only the content area
+// needs styling here.
+
 .FoF-ForumStatisticsWidget {
   .ForumStatisticsList {
     margin: 0;
     padding: 0;
     list-style-type: none;
+  }
+}
+
+// ============================================================
+// Forum Statistics Widget — Classic look
+// ============================================================
+// These styles apply when the "Classic look" admin setting is ON.
+// The --classic modifier is added to the root widget element
+// (which also carries FofWidgets-Widget), so selectors here use
+// &-title / &-content relative to that same root element.
+//
+// Goal: strip the widget chrome (title bar, content card) and
+// restore the original plain sidebar appearance.
+
+.FoF-ForumStatisticsWidget--classic {
+  // Hide the icon + heading rendered by the Widget base class
+  > .FofWidgets-Widget-title {
+    display: none;
+  }
+
+  // Remove the card background/padding/radius from the content wrapper
+  > .FofWidgets-Widget-content {
+    background: transparent;
+    padding: 0;
+    border-radius: 0;
+
+    // Classic content container
+    .ForumStatistics {
+      color: @control-color;
+      width: 100%;
+      margin-top: 20px;
+    }
+
+    #ForumStatisticsList {
+      margin: 0;
+      padding: 0;
+      list-style-type: none;
+      position: relative;
+    }
   }
 }

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -13,6 +13,8 @@ fof-forum-statistics-widget:
       flush_cache_on_new_registration_label: Flush Stats Cache on New Registration
       flush_cache_on_new_registration_help: "If enabled, the stats cache will be flushed when a new user registers on the forum."
       widget_ignore_private_discussions_label: Ignore Private Discussions
+      classic_look_label: Classic Look
+      classic_look_help: "Restore the original widget appearance used before the fof/forum-widgets-core integration."
     permissions:
       view_discussions_count_label: View forum statistics widget discussions count
       view_posts_count_label: View forum statistics widget posts count


### PR DESCRIPTION
Adds a **Classic Look** admin toggle that restores the original widget appearance for forums that prefer it over the new `fof/forum-widgets-core` styling.

## Changes

- **`extend.php`** — registers `classic_look` setting default and serializes it to the forum payload as `fof-forum-statistics-widget.classicLook`
- **`ForumStatisticsWidget.tsx`** — `isClassicLook()` helper reads the forum attribute; `className()` appends `FoF-ForumStatisticsWidget--classic`; `content()` renders the original `ForumStatistics > row > h2 + ul#ForumStatisticsList` markup when enabled
- **`forum.less`** — split into two clearly-commented sections (new look / classic look); the `--classic` modifier hides the widget chrome (title bar, content card) and restores the original `@control-color` list styling
- **`admin/index.ts`** — registers the `classic_look` switch setting
- **`en.yml`** — adds `classic_look_label` and `classic_look_help` strings